### PR TITLE
Setup: Only use sudo when not already root

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-sudo apt-get update || exit $?
-sudo apt-get install --assume-yes lsb-release software-properties-common wget pip cmake|| exit $?
+if [ $UID != 0 ]; then
+  SUDO=sudo
+else
+  SUDO=""
+fi
+
+$SUDO apt-get update || exit $?
+$SUDO apt-get install --assume-yes lsb-release software-properties-common wget pip cmake|| exit $?
 TMP_DIR=$(mktemp -d)
 pushd $TMP_DIR || exit $?
 wget https://apt.llvm.org/llvm.sh || exit $?
 chmod +x llvm.sh || exit $?
-sudo ./llvm.sh 15|| exit $?
-sudo apt install clang-format-15 || exit $?
+$SUDO ./llvm.sh 15|| exit $?
+$SUDO apt install clang-format-15 || exit $?
 pip install "conan==2.0.0b8" || exit $?


### PR DESCRIPTION
This is convenient for Docker, where one by default is root already and `sudo` is not installed.