### PR TITLE
Script to run whatever in an Ubuntu Docker container

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:22.04
+COPY common.sh /tmp/ci/
+COPY setup.sh  /tmp/ci/
+RUN /tmp/ci/setup.sh

--- a/ci/docker_run.sh
+++ b/ci/docker_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $SCRIPT_DIR/common.sh
+
+REALPATH=realpath
+if [ "$OS" == "mac" ]; then
+  REALPATH=grealpath
+fi
+
+HOST_DIR=/host
+WORKING_DIR="$HOST_DIR/$($REALPATH --relative-to=$ROOT_DIR $PWD)"
+DOCKER_TAG=dumbdocker
+DOCKER_ARGS=$@
+
+echo "Building Docker tag '$DOCKER_TAG', running '$DOCKER_ARGS' in '$WORKING_DIR'"
+
+cd $SCRIPT_DIR || exit $?
+docker build . -t $DOCKER_TAG || exit $?
+
+if [ $# -gt 0 ]; then
+  docker run -v $SCRIPT_DIR/..:$HOST_DIR -w $WORKING_DIR $DOCKER_TAG bash -c "$DOCKER_ARGS" || exit $?
+else
+  docker run -it -v $SCRIPT_DIR/..:$HOST_DIR -w $WORKING_DIR $DOCKER_TAG || exit $?
+fi


### PR DESCRIPTION
The working directory inside Docker is set to the same working directory you're in outside of Docker.

If invoked with with no arguments, drops you into an interactive shell in your current working directory.

If invoked with arguments, runs those arguments in Docker. Since the working directory is preserved, relative paths will still work inside Docker.